### PR TITLE
updating replicas to 3 to increase availability

### DIFF
--- a/ms-employee-service/k8s/ms-employee.yaml
+++ b/ms-employee-service/k8s/ms-employee.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ms-employee
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: ms-employee


### PR DESCRIPTION
The front end was having a hard time consistently querying the employee service. my thought is that if we have multiple replicas of the service running, we will have a better time getting responses. To that end, I changed the number of replicas from 1 to 3.